### PR TITLE
ci: Fix 'main-build-and-upload' workflow

### DIFF
--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -20,7 +20,7 @@ jobs:
     needs: [check-merged]
     name: Build and Upload
     if: ${{ needs.check-merged.outputs.is-merged == 'true' }}
-    uses: nubificus/vaccel/.github/workflows/verify-build.yml@main
+    uses: ./.github/workflows/verify-build.yml
     with:
       release: true
       runner-archs: '["amd64", "arm64"]'


### PR DESCRIPTION
Use the local 'verify-build' workflow, that is used for testing the build, in 'main-build-and-upload'