### PR TITLE
fix: Explicitly add missing `ioctl.h` include

### DIFF
--- a/accel.h
+++ b/accel.h
@@ -3,7 +3,9 @@
 #ifndef _ACCEL_H
 #define _ACCEL_H
 
+#include <linux/ioctl.h>
 #include <linux/types.h>
+
 #ifndef __KERNEL__
 #define __user
 #endif


### PR DESCRIPTION
Explicitly add missing `ioctl.h` include in `accel.h` so the IOCTL macros are properly resolved from headers including the latter